### PR TITLE
remove HoverPlugin from require() result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.1.0
+* 利用コンテンツを `akashic export` すると動作しなくなる問題を修正
+  * `require("@akashic-extension/akashic-hover-plugin").HoverPlugin` がなくなります。
+  * ゲーム開発者がこの値を参照する必要は通常ありませんが、
+    必要な場合は `require("@akashic-extension/akashic-hover-plugin/lib/HoverPlugin")` をご利用ください。
+
 ## 2.0.1
 * TypeScript の `strict: true` 指定時にビルドが失敗する件の修正
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-hover-plugin",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-hover-plugin",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A plugin handling mouse hover/unhover events easily for Akashic Engine",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/sample/game.json
+++ b/sample/game.json
@@ -24,6 +24,11 @@
 			"width": 128,
 			"height": 288,
 			"path": "image/aco.png"
+		},
+		"hover_plugin": {
+			"type": "script",
+			"path": "node_modules/@akashic-extension/akashic-hover-plugin/lib/HoverPlugin.js",
+			"global": true
 		}
 	},
 	"operationPlugins": [
@@ -37,7 +42,6 @@
 	],
 	"globalScripts": [
 		"node_modules/@akashic-extension/akashic-hover-plugin/lib/Converter.js",
-		"node_modules/@akashic-extension/akashic-hover-plugin/lib/HoverPlugin.js",
 		"node_modules/@akashic-extension/akashic-hover-plugin/lib/index.js"
 	],
 	"moduleMainScripts": {

--- a/sample/package.json
+++ b/sample/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "@akashic-extension/akashic-hover-plugin": "~2.0.1"
+    "@akashic-extension/akashic-hover-plugin": "~2.1.0"
   },
   "devDependencies": {
     "@akashic/akashic-cli-scan": "~0.2.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,2 @@
 export { Converter } from "./Converter";
 export { HoverableE } from "./HoverableE";
-export { HoverPluginOptions } from "./HoverPluginOptions";
-export { HoverPlugin } from "./HoverPlugin";


### PR DESCRIPTION
掲題どおり。

利用コンテンツで `akashic export html --atsumaru` や `akashic export zip` を実行すると、出力が実行できないゲームになってしまう問題を解消します。

これにより npm install だけでは導入できなくなり、game.json を手動で編集する必要が生じますが、README はもともと既にそれを想定したものになっているので、文書を変更する必要はありませんでした。
