### PR TITLE
fix: Converter.asUnhoverable メソッドの戻り値の型を g.E に修正

### DIFF
--- a/src/Converter.ts
+++ b/src/Converter.ts
@@ -35,7 +35,7 @@ export class Converter {
 	/**
 	 * エンティティのホバーを解除する。
 	 */
-	static asUnhoverable(e: g.E): HoverableE {
+	static asUnhoverable(e: g.E): g.E {
 		const hoverableE = e as HoverableE;
 		delete hoverableE.hoverable;
 		if (hoverableE.hovered && ! hoverableE.hovered.destroyed()) {

--- a/src/Converter.ts
+++ b/src/Converter.ts
@@ -36,7 +36,7 @@ export class Converter {
 	 * エンティティのホバーを解除する。
 	 */
 	static asUnhoverable(e: g.E): g.E {
-		const hoverableE = e as HoverableE;
+		const hoverableE = e as Partial<HoverableE>;
 		delete hoverableE.hoverable;
 		if (hoverableE.hovered && ! hoverableE.hovered.destroyed()) {
 			hoverableE.hovered.destroy();
@@ -47,6 +47,6 @@ export class Converter {
 			hoverableE.unhovered.destroy();
 			delete hoverableE.unhovered;
 		}
-		return hoverableE;
+		return hoverableE as g.E;
 	}
 }


### PR DESCRIPTION
メソッド名・内容的に、このメソッドを通したエンティティは`HoverableE`ではなく`g.E`であるべきだと考えたので、`Converter.asUnhoverable`メソッドの戻り値の型を`HoverableE`から`g.E`に修正しました。

戻り値の型が変わるので、ゲーム製作者が戻り値を`HoverableE`として扱っている場合は対応が必要になります。