### PR TITLE
Export plugin type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.2.1
+* HoverPlugin の型定義を export するように修正
+
 ## 3.2.0
 * `HoverPlugin#getLatestHoveredPoint()` の追加
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-hover-plugin",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A plugin handling mouse hover/unhover events easily for Akashic Engine",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HoverPlugin.ts
+++ b/src/HoverPlugin.ts
@@ -5,9 +5,6 @@ export interface HoverPluginLike extends g.OperationPlugin {
 	game: g.Game;
 	view: HTMLElement;
 	beforeHover: HoverableE | null;
-	operationTrigger: g.Trigger<g.OperationPluginOperation | (number | string)[]>;
-	start(): boolean;
-	stop(): void;
 	getLatestHoveredPoint(): g.CommonOffset | null;
 }
 

--- a/src/HoverPlugin.ts
+++ b/src/HoverPlugin.ts
@@ -1,10 +1,25 @@
 import { HoverableE } from "./HoverableE";
 import { HoverPluginOptions } from "./HoverPluginOptions";
 
+export interface HoverPluginLike extends g.OperationPlugin {
+	game: g.Game;
+	view: HTMLElement;
+	beforeHover: HoverableE | null;
+	operationTrigger: g.Trigger<g.OperationPluginOperation | (number | string)[]>;
+	start(): boolean;
+	stop(): void;
+	getLatestHoveredPoint(): g.CommonOffset | null;
+}
+
+export interface HoverPluginStatic {
+	isSupported: () => boolean;
+	new (game: any, viewInfo: g.OperationPluginViewInfo | null, option?: any): HoverPluginLike;
+}
+
 /**
  * ホバー機能を提供するプラグイン。
  */
-class HoverPlugin implements g.OperationPlugin {
+class HoverPlugin implements HoverPluginLike {
 	game: g.Game;
 	view: HTMLElement;
 	beforeHover: HoverableE | null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 export { Converter } from "./Converter";
 export { HoverableE } from "./HoverableE";
+import { HoverPluginStatic } from "./HoverPlugin";
+export  { HoverPluginLike, HoverPluginStatic } from "./HoverPlugin";
 
 // HoverPlugin.ts で module.exports しているため、そのまま export すると使用側で型がおかしくなる。
 // 後方互換性のため module.exports は残しここでキャストしている。
 import * as plugin from "./HoverPlugin";
-const hoverPlugin = plugin as g.OperationPluginStatic;
-export { hoverPlugin as HoverPlugin };
+const hoverPlugin = plugin as HoverPluginStatic;
+export { hoverPlugin };


### PR DESCRIPTION
## このpull requestが解決する内容

HoverPluginのユーザが型定義を利用できるようにします。
従来は `g.OperationPluginStatic` としてexportしていたため、HoverPlugin固有の型を利用することができませんでした。
この問題を解決します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

